### PR TITLE
Add new user connection handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.4
+VERSION := 1.1.0
 NAME := freki
 GH_PATH := github.com/kung-foo/$(NAME)
 BUILDSTRING := $(shell git log --pretty=format:'%h' -n 1)

--- a/app/rules.yaml
+++ b/app/rules.yaml
@@ -1,3 +1,4 @@
+version: 1
 rules:
   - match: tcp dst port 22 and src host 1.2.3.4
     type: passthrough
@@ -14,6 +15,9 @@ rules:
     type: log_http
   - match: tcp portrange 5000-5010
     type: drop
+  - match: tcp portrange 7000-8000
+    type: conn_handler
+    target: echo
   - match: tcp port 8888
     type: drop
   - match: tcp

--- a/conntable.go
+++ b/conntable.go
@@ -31,6 +31,11 @@ func NewConnKeyByString(host, port string) ckey {
 	return NewConnKeyByEndpoints(clientAddr, clientPort)
 }
 
+func NewConnKeyFromNetConn(conn net.Conn) ckey {
+	host, port, _ := net.SplitHostPort(conn.RemoteAddr().String())
+	return NewConnKeyByString(host, port)
+}
+
 type Metadata struct {
 	Added      time.Time
 	Rule       *Rule

--- a/userconnhandler_tcp.go
+++ b/userconnhandler_tcp.go
@@ -1,0 +1,91 @@
+package freki
+
+import (
+	"fmt"
+	"net"
+	"runtime/debug"
+
+	"github.com/pkg/errors"
+)
+
+type UserConnServer struct {
+	port      uint
+	processor *Processor
+	log       Logger
+	listener  net.Listener
+}
+
+func NewUserConnServer(port uint) *UserConnServer {
+	return &UserConnServer{
+		port: port,
+	}
+}
+
+func (h *UserConnServer) Port() uint {
+	return h.port
+}
+
+func (h *UserConnServer) Type() string {
+	return "user.tcp"
+}
+
+func (h *UserConnServer) Start(processor *Processor) error {
+	h.processor = processor
+	h.log = h.processor.log
+
+	var err error
+	// TODO: can I be more specific with the bind addr?
+	h.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", h.port))
+
+	if err != nil {
+		return err
+	}
+
+	for {
+		conn, err := h.listener.Accept()
+		if err != nil {
+			h.log.Errorf("[user.tcp] %v", err)
+			continue
+		}
+
+		host, port, _ := net.SplitHostPort(conn.RemoteAddr().String())
+		ck := NewConnKeyByString(host, port)
+		md := h.processor.Connections.GetByFlow(ck)
+
+		if md == nil {
+			h.log.Warnf("[user.tcp] untracked connection: %s", conn.RemoteAddr().String())
+			conn.Close()
+			continue
+		}
+
+		// TODO: there is no connection between freki and the handler
+		// once freki starts to shutdown, handlers are not notified.
+		// maybe use a Context?
+		if hfunc, ok := h.processor.connHandlers[md.Rule.Target]; ok {
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						h.log.Errorf("[user.tcp] panic: %+v", r)
+						h.log.Errorf("[user.tcp] stacktrace:\n%v", string(debug.Stack()))
+						conn.Close()
+					}
+				}()
+				err := hfunc(conn, md)
+				if err != nil {
+					h.log.Error(errors.Wrap(err, h.Type()))
+				}
+			}()
+		} else {
+			h.log.Errorf("[user.tcp] %v", fmt.Errorf("no handler found for %s", md.Rule.Target))
+			conn.Close()
+			continue
+		}
+	}
+}
+
+func (h *UserConnServer) Shutdown() error {
+	if h.listener != nil {
+		return h.listener.Close()
+	}
+	return nil
+}

--- a/userconnhandler_tcp.go
+++ b/userconnhandler_tcp.go
@@ -48,8 +48,7 @@ func (h *UserConnServer) Start(processor *Processor) error {
 			continue
 		}
 
-		host, port, _ := net.SplitHostPort(conn.RemoteAddr().String())
-		ck := NewConnKeyByString(host, port)
+		ck := NewConnKeyFromNetConn(conn)
 		md := h.processor.Connections.GetByFlow(ck)
 
 		if md == nil {


### PR DESCRIPTION
This PR adds the ability to have user specified handlers of tcp connections. This only applies to projects using **freki** as a library.

Example rules:

```yaml
rules:
  - match: tcp portrange 7000-8000
    type: conn_handler
    target: echo
```

The new **type** is `conn_handler` and the **target** is the named handler.

Handlers are registered with the **freki** instance:

```go
processor.RegisterConnHandler("echo", func(conn net.Conn, md *freki.Metadata) error {
	defer conn.Close()
	host, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
	logger.Infof("[main    ] echo request %s -> %d", host, uint(md.TargetPort))
	io.Copy(conn, conn)
	return nil
})
```

Handlers are also executed in a separate goroutine with a panic handler.
