### PR TITLE
libnetfilter_queue invalid argument

### DIFF
--- a/netfilter/netfilter.h
+++ b/netfilter/netfilter.h
@@ -34,7 +34,7 @@ extern void go_callback(int id, unsigned char* data, int len, int queue_id);
 static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct nfq_data *nfa, void *cb_data){
     uint32_t id = -1;
     struct nfqnl_msg_packet_hdr *ph = NULL;
-    unsigned char *buffer = NULL;
+    char *buffer = NULL;
     int ret = 0;
 
     // nfq_get_packet_hw


### PR DESCRIPTION
``vendor/github.com/kung-foo/freki/netfilter/netfilter.h:49:9: error: passing argument 2 of ‘nfq_get_payload’ from incompatible pointer type [-Werror]
/usr/include/libnetfilter_queue/libnetfilter_queue.h:99:12: note: expected ‘char **’ but argument is of type ‘unsigned char **’``
Reference Link: https://travis-ci.org/mushorg/glutton#L324